### PR TITLE
New OPSG in verilog, verifies all features I know of in testbench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.out
+*.vcd
+*.geany

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -631,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    {one line to give the program's name and a brief idea of what it does.}
+    Copyright (C) {year}  {name of author}
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -645,14 +645,14 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    <program>  Copyright (C) <year>  <name of author>
+    {project}  Copyright (C) {year}  {fullname}
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<https://www.gnu.org/licenses/>.
+<http://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<https://www.gnu.org/licenses/why-not-lgpl.html>.
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# OPŜG
+A verilog implementation of variants of the SN76489 programmable sound generator.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# OPŜG
+# OPSG
 A verilog implementation of variants of the SN76489 programmable sound generator.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # OPSG
-A verilog implementation of variants of the SN76489 programmable sound generator.
+A verilog implementation of variants of the SN76489 programmable sound generator. It aims to provide a parameterized module which can closely replicate the behaviour of all the variants by providing
+options for things like: tapped bits, shift register size, etc...
+
+## Copyright and Disclaimer
+Copyright: René Richard 2018
+
+OPSG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+OPSG is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with OPSG.  If not, see <http://www.gnu.org/licenses/>.
+
+# Simulation
+Run the test benches with iverilog using the following commands:
+```
+iverilog [testbench.v] [design.v] -o wave.out
+```
+Then, use vvp to convert the 'test.out' file into a format .bcd which gtkwave can view:
+```
+vvp wave.out
+```
+Finally, open the waveform using gtkwave:
+```
+gtkwave dump.bcd
+```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Then, use vvp to convert the 'test.out' file into a format .bcd which gtkwave ca
 ```
 vvp wave.out
 ```
+You could obviously run the above in one line if you're fancy:
+```
+iverilog [testbench.v] [design.v] -o wave.out & vvp wave.out
+```
 Finally, open the waveform using gtkwave:
 ```
 gtkwave dump.bcd

--- a/opsg.v
+++ b/opsg.v
@@ -52,10 +52,6 @@ module opsg #(
 	reg [2:0] ctrl4 = 3'b100;
 	reg [2:0] prev_reg = 3'b000;
 	reg noise_reload = 0;
-
-	// audio summing
-	reg [15:0] aleft;
-	reg [15:0] aright;
   
 	// each bit of attenuation corresponds to 2dB
 	// 2dB = 10^(-0.1) = 0.79432823
@@ -101,13 +97,13 @@ module opsg #(
 		end
 	endfunction
   
-	//divide the master clock by 32
+	//divide the master clock by 32, testbenches can reduce this value to shrink the waveform size
 	always @(posedge clk) begin
 		clk_div <= clk_div + 1;
 	end
-	// 
 	assign clk32 = clk_div[CLK_DIV];
   
+	// TODO add left/right control bits for Gamegear mode
 	// assign weighted audio outputs to channels
 	assign audio_left = (ch1 ? vol_table(vol1) : 0) + (ch2 ? vol_table(vol2) : 0) + (ch3 ? vol_table(vol3) : 0) + (ch4 ? vol_table(vol4) : 0)   ;
 	assign audio_right = audio_left;

--- a/opsg.v
+++ b/opsg.v
@@ -23,158 +23,165 @@
 `include "opsg_noise.v"
 
 module opsg #(
-  parameter TAPPED_BIT0 = 0,
-  parameter TAPPED_BIT1 = 3,
-  parameter SHIFT_WIDTH = 15,
-  parameter TONE_WIDTH = 10,
-  parameter MAX_VOLUME = 4096,
-  parameter CLK_DIV = 4
+	parameter TAPPED_BIT0 = 0,
+	parameter TAPPED_BIT1 = 3,
+	parameter SHIFT_WIDTH = 15,
+	parameter TONE_WIDTH = 10,
+	parameter MAX_VOLUME = 4096,
+	parameter CLK_DIV = 4
 )(
-  input clk, n_rst, n_wr,
-  input [7:0] data,
-  output ch1, ch2, ch3, ch4,
-  output [15:0] audio_left,
-  output [15:0] audio_right
+	input clk, n_rst, n_wr,
+	input [7:0] data,
+	output ch1, ch2, ch3, ch4,
+	output [15:0] audio_left,
+	output [15:0] audio_right
 );
 
-  //clock divider
-  reg [4:0] clk_div = 0;
-  wire clk32;
+	//clock divider
+	reg [4:0] clk_div = 0;
+	wire clk32;
 
-  //tone, vol, ctrl registers
-  reg [TONE_WIDTH-1:0] freq1 = 1;
-  reg [TONE_WIDTH-1:0] freq2 = 1;
-  reg [TONE_WIDTH-1:0] freq3 = 1;
-  reg [3:0] vol1 = 4'b1111;
-  reg [3:0] vol2 = 4'b1111;
-  reg [3:0] vol3 = 4'b1111;
-  reg [3:0] vol4 = 4'b1111;
-  reg [2:0] ctrl4 = 3'b100;
-  reg [2:0] prev_reg = 3'b000;
+	//tone, vol, ctrl registers
+	reg [TONE_WIDTH-1:0] freq1 = 1;
+	reg [TONE_WIDTH-1:0] freq2 = 1;
+	reg [TONE_WIDTH-1:0] freq3 = 1;
+	reg [3:0] vol1 = 4'b1111;
+	reg [3:0] vol2 = 4'b1111;
+	reg [3:0] vol3 = 4'b1111;
+	reg [3:0] vol4 = 4'b1111;
+	reg [2:0] ctrl4 = 3'b100;
+	reg [2:0] prev_reg = 3'b000;
+	reg noise_reload = 0;
+
+	// audio summing
+	reg [15:0] aleft;
+	reg [15:0] aright;
   
-  // audio summing
-  reg [15:0] aleft;
-  reg [15:0] aright;
+	// each bit of attenuation corresponds to 2dB
+	// 2dB = 10^(-0.1) = 0.79432823
+	function [15:0] vol_table;
+		input [3:0] vol;
+		reg [15:0] vol_temp;
+		begin
+			case(vol)
+				0  : vol_temp = MAX_VOLUME;
+				1  : vol_temp = MAX_VOLUME * 0.79432823;
+				2  : vol_temp = MAX_VOLUME * 0.63095734;
+				3  : vol_temp = MAX_VOLUME * 0.50118723;
+				4  : vol_temp = MAX_VOLUME * 0.39810717;
+				5  : vol_temp = MAX_VOLUME * 0.31622777;
+				6  : vol_temp = MAX_VOLUME * 0.25118864;
+				7  : vol_temp = MAX_VOLUME * 0.19952623;
+				8  : vol_temp = MAX_VOLUME * 0.15848932;
+				9  : vol_temp = MAX_VOLUME * 0.12589254;
+				10 : vol_temp = MAX_VOLUME * 0.10000000;
+				11 : vol_temp = MAX_VOLUME * 0.07943282;
+				12 : vol_temp = MAX_VOLUME * 0.06309573;
+				13 : vol_temp = MAX_VOLUME * 0.05011872;
+				14 : vol_temp = MAX_VOLUME * 0.03981072;
+				default : vol_temp = 0;
+			endcase
+		  //$display("att: %d vol: %d",vol,vol_temp);
+		  vol_table = vol_temp;
+		end
+	endfunction
   
-  // each bit of attenuation corresponds to 2dB
-  // 2dB = 10^(-0.1) = 0.79432823
-  function [15:0] vol_table;
-    input [3:0] vol;
-    reg [15:0] vol_temp;
-    begin
-      case(vol)
-        0  : vol_temp = MAX_VOLUME;
-        1  : vol_temp = MAX_VOLUME * 0.79432823;
-        2  : vol_temp = MAX_VOLUME * 0.63095734;
-        3  : vol_temp = MAX_VOLUME * 0.50118723;
-        4  : vol_temp = MAX_VOLUME * 0.39810717;
-        5  : vol_temp = MAX_VOLUME * 0.31622777;
-        6  : vol_temp = MAX_VOLUME * 0.25118864;
-        7  : vol_temp = MAX_VOLUME * 0.19952623;
-        8  : vol_temp = MAX_VOLUME * 0.15848932;
-        9  : vol_temp = MAX_VOLUME * 0.12589254;
-        10 : vol_temp = MAX_VOLUME * 0.10000000;
-        11 : vol_temp = MAX_VOLUME * 0.07943282;
-        12 : vol_temp = MAX_VOLUME * 0.06309573;
-        13 : vol_temp = MAX_VOLUME * 0.05011872;
-        14 : vol_temp = MAX_VOLUME * 0.03981072;
-        default : vol_temp = 0;
-      endcase
-      //$display("att: %d vol: %d",vol,vol_temp);
-      vol_table = vol_temp;
-    end
-  endfunction
+	//divide the master clock by 32
+	always @(posedge clk) begin
+		clk_div <= clk_div + 1;
+	end
+	// 
+	assign clk32 = clk_div[CLK_DIV];
   
-  //divide the master clock by 32
-  always @(posedge clk) begin
-    clk_div <= clk_div + 1;
-  end
-  // 
-  assign clk32 = clk_div[CLK_DIV];
+	// assign weighted audio outputs to channels
+	assign audio_left = (ch1 ? vol_table(vol1) : 0) + (ch2 ? vol_table(vol2) : 0) + (ch3 ? vol_table(vol3) : 0) + (ch4 ? vol_table(vol4) : 0)   ;
+	assign audio_right = audio_left;
   
-  // assign weighted audio outputs to channels
-  assign audio_left = (ch1 ? vol_table(vol1) : 0) + (ch2 ? vol_table(vol2) : 0) + (ch3 ? vol_table(vol3) : 0) + (ch4 ? vol_table(vol4) : 0)   ;
-  assign audio_right = audio_left;
+	// CHANNEL 1
+	opsg_tone #(
+		.TONE_WIDTH(TONE_WIDTH)
+	) psg_ch1(
+		.clk(clk32),
+		.freq(freq1),
+		.toneBit(ch1)
+	);
   
-  // CHANNEL 1
-  opsg_tone #(
-    .TONE_WIDTH(TONE_WIDTH)
-  ) psg_ch1(
-    .clk(clk32),
-    .freq(freq1),
-    .toneBit(ch1)
-  );
+	// CHANNEL 2
+	opsg_tone #(
+		.TONE_WIDTH(TONE_WIDTH)
+	) psg_ch2 (
+		.clk(clk32),
+		.freq(freq2),
+		.toneBit(ch2)
+	);
   
-  // CHANNEL 2
-  opsg_tone #(
-    .TONE_WIDTH(TONE_WIDTH)
-  ) psg_ch2 (
-    .clk(clk32),
-    .freq(freq2),
-    .toneBit(ch2)
-  );
+	// CHANNEL 3
+	opsg_tone #(
+		.TONE_WIDTH(TONE_WIDTH)
+	) psg_ch3 (
+		.clk(clk32),
+		.freq(freq3),
+		.toneBit(ch3)
+	);
   
-  // CHANNEL 3
-  opsg_tone #(
-    .TONE_WIDTH(TONE_WIDTH)
-  ) psg_ch3 (
-    .clk(clk32),
-    .freq(freq3),
-    .toneBit(ch3)
-  );
-  
-  // NOISE CHANNEL
-  opsg_noise #(
-    .TAPPED_BIT0(0),
-    .TAPPED_BIT1(3),
-    .SHIFT_WIDTH(15),
-    .TONE_WIDTH(TONE_WIDTH)
-  ) psg_noise (
-    .clk(clk32),
-    .fb(ctrl4[2]),
-    .nf(ctrl4[1:0]),
-    .freq(freq3),
-    .noiseBit(ch4)
-  );
+	// NOISE CHANNEL
+	opsg_noise #(
+		.TAPPED_BIT0(0),
+		.TAPPED_BIT1(3),
+		.SHIFT_WIDTH(15),
+		.TONE_WIDTH(TONE_WIDTH)
+	) psg_noise (
+		.clk(clk32),
+		.reload(noise_reload),
+		.fb(ctrl4[2]),
+		.nf(ctrl4[1:0]),
+		.freq(freq3),
+		.noiseBit(ch4)
+	);
   
   //data input
-  always @(posedge clk, negedge n_rst) begin
-    if (!n_rst) begin
-      vol1 = 4'b1111;
-      vol2 = 4'b1111;
-      vol3 = 4'b1111;
-      vol4 = 4'b1111;
-      ctrl4 = 3'b100;
-    end else begin
-      if (!n_wr) begin
-        if (data[7] == 1'b1) begin
-          case(data[6:4])
-          	3'b000 : freq1[3:0] <= data[3:0];
-            3'b010 : freq2[3:0] <= data[3:0];
-            3'b100 : freq3[3:0] <= data[3:0];
-            3'b110 : ctrl4 <= data[2:0];
-            3'b001 : vol1[3:0] <= data[3:0];
-            3'b011 : vol2[3:0] <= data[3:0];
-            3'b101 : vol3[3:0] <= data[3:0];
-            3'b111 : vol4[3:0] <= data[3:0];
-            default : begin end
-          endcase
-          prev_reg <= data[6:4];
-        end else begin
-          case(prev_reg)
-            3'b000 : freq1[9:4] <= data[5:0];
-            3'b010 : freq2[9:4] <= data[5:0];
-            3'b100 : freq3[9:4] <= data[5:0];
-            3'b001 : vol1[3:0] <= data[3:0];
-            3'b011 : vol2[3:0] <= data[3:0];
-            3'b101 : vol3[3:0] <= data[3:0];
-            3'b111 : vol4[3:0] <= data[3:0];
-            default : begin end
-          endcase
-        end
-      end
-    end
-  end
-  
+	always @(posedge clk, negedge n_rst) begin
+		if (!n_rst) begin
+			vol1 = 4'b1111;
+			vol2 = 4'b1111;
+			vol3 = 4'b1111;
+			vol4 = 4'b1111;
+			ctrl4 = 3'b100;
+			noise_reload = 0;
+		end else begin
+			noise_reload <= 1;
+			if (!n_wr) begin
+				if (data[7] == 1'b1) begin
+					case(data[6:4])
+						3'b000 : freq1[3:0] <= data[3:0];
+						3'b010 : freq2[3:0] <= data[3:0];
+						3'b100 : freq3[3:0] <= data[3:0];
+						3'b110 : 
+							begin 
+								ctrl4 <= data[2:0];
+								noise_reload <= 0;
+							end
+						3'b001 : vol1[3:0] <= data[3:0];
+						3'b011 : vol2[3:0] <= data[3:0];
+						3'b101 : vol3[3:0] <= data[3:0];
+						3'b111 : vol4[3:0] <= data[3:0];
+						default : begin end
+					endcase
+					prev_reg <= data[6:4];
+				end else begin
+					case(prev_reg)
+						3'b000 : freq1[9:4] <= data[5:0];
+						3'b010 : freq2[9:4] <= data[5:0];
+						3'b100 : freq3[9:4] <= data[5:0];
+						3'b001 : vol1[3:0] <= data[3:0];
+						3'b011 : vol2[3:0] <= data[3:0];
+						3'b101 : vol3[3:0] <= data[3:0];
+						3'b111 : vol4[3:0] <= data[3:0];
+						default : begin end
+					endcase
+				end
+			end
+		end
+	end
   
 endmodule

--- a/opsg.v
+++ b/opsg.v
@@ -59,26 +59,41 @@ module opsg #(
   
 	// each bit of attenuation corresponds to 2dB
 	// 2dB = 10^(-0.1) = 0.79432823
-	function [15:0] vol_table;
+	`define _OPSG_VOL1  (MAX_VOLUME * 0.79432823)
+	`define _OPSG_VOL2  (MAX_VOLUME * 0.63095734)
+	`define _OPSG_VOL3  (MAX_VOLUME * 0.50118723)
+	`define _OPSG_VOL4  (MAX_VOLUME * 0.39810717)
+	`define _OPSG_VOL5  (MAX_VOLUME * 0.31622777)
+	`define _OPSG_VOL6  (MAX_VOLUME * 0.25118864)
+	`define _OPSG_VOL7  (MAX_VOLUME * 0.19952623)
+	`define _OPSG_VOL8  (MAX_VOLUME * 0.15848932)
+	`define _OPSG_VOL9  (MAX_VOLUME * 0.12589254)
+	`define _OPSG_VOL10 (MAX_VOLUME * 0.10000000)
+	`define _OPSG_VOL11 (MAX_VOLUME * 0.07943282)
+	`define _OPSG_VOL12 (MAX_VOLUME * 0.06309573)
+	`define _OPSG_VOL13 (MAX_VOLUME * 0.05011872)
+	`define _OPSG_VOL14 (MAX_VOLUME * 0.03981072)
+	
+	 function [15:0] vol_table;
 		input [3:0] vol;
 		reg [15:0] vol_temp;
 		begin
 			case(vol)
 				0  : vol_temp = MAX_VOLUME;
-				1  : vol_temp = MAX_VOLUME * 0.79432823;
-				2  : vol_temp = MAX_VOLUME * 0.63095734;
-				3  : vol_temp = MAX_VOLUME * 0.50118723;
-				4  : vol_temp = MAX_VOLUME * 0.39810717;
-				5  : vol_temp = MAX_VOLUME * 0.31622777;
-				6  : vol_temp = MAX_VOLUME * 0.25118864;
-				7  : vol_temp = MAX_VOLUME * 0.19952623;
-				8  : vol_temp = MAX_VOLUME * 0.15848932;
-				9  : vol_temp = MAX_VOLUME * 0.12589254;
-				10 : vol_temp = MAX_VOLUME * 0.10000000;
-				11 : vol_temp = MAX_VOLUME * 0.07943282;
-				12 : vol_temp = MAX_VOLUME * 0.06309573;
-				13 : vol_temp = MAX_VOLUME * 0.05011872;
-				14 : vol_temp = MAX_VOLUME * 0.03981072;
+				1  : vol_temp = `_OPSG_VOL1;
+				2  : vol_temp = `_OPSG_VOL2;
+				3  : vol_temp = `_OPSG_VOL3;
+				4  : vol_temp = `_OPSG_VOL4;
+				5  : vol_temp = `_OPSG_VOL5;
+				6  : vol_temp = `_OPSG_VOL6;
+				7  : vol_temp = `_OPSG_VOL7;
+				8  : vol_temp = `_OPSG_VOL8;
+				9  : vol_temp = `_OPSG_VOL9;
+				10 : vol_temp = `_OPSG_VOL10;
+				11 : vol_temp = `_OPSG_VOL11;
+				12 : vol_temp = `_OPSG_VOL12;
+				13 : vol_temp = `_OPSG_VOL13;
+				14 : vol_temp = `_OPSG_VOL14;
 				default : vol_temp = 0;
 			endcase
 		  //$display("att: %d vol: %d",vol,vol_temp);

--- a/opsg.v
+++ b/opsg.v
@@ -1,0 +1,241 @@
+// TONE CHANNEL
+module opsg_tone #(
+  parameter TONE_WIDTH = 10
+)(
+  input clk,
+  input [TONE_WIDTH-1:0] freq,
+  output reg [TONE_WIDTH-1:0] count,
+  output reg toneBit
+);
+
+  // init counter to 1, tbit to 1;
+  reg [TONE_WIDTH-1:0] counter = 1;
+  reg tbit = 1'b1;
+  
+  always @(posedge clk) begin
+    if ( counter == 0 ) begin
+      // output of tone channel forced to 1 if freq == 0 or 1 (used for sample playback)
+      if ( freq == 0 || freq == 1 ) begin
+        tbit <= 1'b1;
+      //else reload counter and toggle the output
+      end else begin
+        counter <= freq;
+    	tbit <= !tbit;
+      end
+    end else begin
+      	counter <= counter - 1;
+    end
+    //out = ( v == 1'b1) ? { VOLUME_WIDTH {1'b0} } : volume;
+    count = counter;
+    toneBit = tbit;
+  end
+  
+endmodule
+
+// NOISE CHANNEL
+module opsg_noise #(
+  parameter TAPPED_BIT0 = 0,
+  parameter TAPPED_BIT1 = 3,
+  parameter SHIFT_WIDTH = 15,
+  parameter TONE_WIDTH = 10
+)(
+  input clk,
+  input fb,
+  input [1:0] nf,
+  input [TONE_WIDTH-1:0] freq,
+  output reg [TONE_WIDTH-1:0] count,
+  output reg [SHIFT_WIDTH-1:0] shiftReg,
+  output reg noiseBit
+);
+  
+  // init counter to 1, nbit to 1;
+  reg [TONE_WIDTH-1:0] counter = 1;
+  reg [SHIFT_WIDTH-1:0] shift = { 1'b1, { SHIFT_WIDTH-1 {1'b0} } };
+  reg nbit = 1'b1;
+  reg feedback;
+  
+  always @(posedge clk) begin
+    if ( counter == 1 ) begin
+      case(nf)
+        2'b00 : counter <= 16;
+        2'b01 : counter <= 32;
+        2'b10 : counter <= 64;
+        // noiseFreq to be connected to tone channel 3
+        default : counter <= freq;
+      endcase
+   	  nbit <= !nbit;
+    end else begin
+      counter <= counter - 1;
+    end
+    count = counter;
+  end
+  
+  always @(posedge nbit) begin
+    if (fb) begin
+      shift <= { (shift[TAPPED_BIT0] ^ shift[TAPPED_BIT1]), shift[SHIFT_WIDTH-1:1] };
+    end else begin
+      shift <= { shift[0], shift[SHIFT_WIDTH-1:1] };
+    end
+    shiftReg = shift;
+    noiseBit = shift[0];
+  end
+  
+endmodule
+
+  // The PSG
+module opsg #(
+  parameter TAPPED_BIT0 = 0,
+  parameter TAPPED_BIT1 = 3,
+  parameter SHIFT_WIDTH = 15,
+  parameter TONE_WIDTH = 10,
+  parameter MAX_VOLUME = 4096,
+  parameter CLK_DIV = 4
+)(
+  input clk, n_rst, n_wr,
+  input [7:0] data,
+  output ch1, ch2, ch3, ch4,
+  output [15:0] audio_left,
+  output [15:0] audio_right
+);
+
+  //clock divider
+  reg [4:0] clk_div = 0;
+  wire clk32;
+
+  //tone, vol, ctrl registers
+  reg [TONE_WIDTH-1:0] freq1 = 1;
+  reg [TONE_WIDTH-1:0] freq2 = 1;
+  reg [TONE_WIDTH-1:0] freq3 = 1;
+  reg [3:0] vol1 = 4'b1111;
+  reg [3:0] vol2 = 4'b1111;
+  reg [3:0] vol3 = 4'b1111;
+  reg [3:0] vol4 = 4'b1111;
+  reg [2:0] ctrl4 = 3'b100;
+  reg [2:0] prev_reg = 3'b000;
+  
+  // audio summing
+  reg [15:0] aleft;
+  reg [15:0] aright;
+  
+  // each bit of attenuation corresponds to 2dB
+  // 2dB = 10^(-0.1) = 0.79432823
+  function [15:0] vol_table;
+    input [3:0] vol;
+    reg [15:0] vol_temp;
+    begin
+      case(vol)
+        0  : vol_temp = MAX_VOLUME;
+        1  : vol_temp = MAX_VOLUME * 0.79432823;
+        2  : vol_temp = MAX_VOLUME * 0.63095734;
+        3  : vol_temp = MAX_VOLUME * 0.50118723;
+        4  : vol_temp = MAX_VOLUME * 0.39810717;
+        5  : vol_temp = MAX_VOLUME * 0.31622777;
+        6  : vol_temp = MAX_VOLUME * 0.25118864;
+        7  : vol_temp = MAX_VOLUME * 0.19952623;
+        8  : vol_temp = MAX_VOLUME * 0.15848932;
+        9  : vol_temp = MAX_VOLUME * 0.12589254;
+        10 : vol_temp = MAX_VOLUME * 0.10000000;
+        11 : vol_temp = MAX_VOLUME * 0.07943282;
+        12 : vol_temp = MAX_VOLUME * 0.06309573;
+        13 : vol_temp = MAX_VOLUME * 0.05011872;
+        14 : vol_temp = MAX_VOLUME * 0.03981072;
+        default : vol_temp = 0;
+      endcase
+      //$display("att: %d vol: %d",vol,vol_temp);
+      vol_table = vol_temp;
+    end
+  endfunction
+  
+  //divide the master clock by 32
+  always @(posedge clk) begin
+    clk_div <= clk_div + 1;
+  end
+  // 
+  assign clk32 = clk_div[CLK_DIV];
+  
+  // assign weighted audio outputs to channels
+  assign audio_left = (ch1 ? vol_table(vol1) : 0) + (ch2 ? vol_table(vol2) : 0) + (ch3 ? vol_table(vol3) : 0) + (ch4 ? vol_table(vol4) : 0)   ;
+  assign audio_right = audio_left;
+  
+  // CHANNEL 1
+  opsg_tone #(
+    .TONE_WIDTH(TONE_WIDTH)
+  ) psg_ch1(
+    .clk(clk32),
+    .freq(freq1),
+    .toneBit(ch1)
+  );
+  
+  // CHANNEL 2
+  opsg_tone #(
+    .TONE_WIDTH(TONE_WIDTH)
+  ) psg_ch2 (
+    .clk(clk32),
+    .freq(freq2),
+    .toneBit(ch2)
+  );
+  
+  // CHANNEL 3
+  opsg_tone #(
+    .TONE_WIDTH(TONE_WIDTH)
+  ) psg_ch3 (
+    .clk(clk32),
+    .freq(freq3),
+    .toneBit(ch3)
+  );
+  
+  // NOISE CHANNEL
+  opsg_noise #(
+    .TAPPED_BIT0(0),
+    .TAPPED_BIT1(3),
+    .SHIFT_WIDTH(15),
+    .TONE_WIDTH(TONE_WIDTH)
+  ) psg_noise (
+    .clk(clk32),
+    .fb(ctrl4[2]),
+    .nf(ctrl4[1:0]),
+    .freq(freq3),
+    .noiseBit(ch4)
+  );
+  
+  //data input
+  always @(posedge clk, negedge n_rst) begin
+    if (!n_rst) begin
+      vol1 = 4'b1111;
+      vol2 = 4'b1111;
+      vol3 = 4'b1111;
+      vol4 = 4'b1111;
+      ctrl4 = 3'b100;
+    end else begin
+      if (!n_wr) begin
+        if (data[7] == 1'b1) begin
+          case(data[6:4])
+          	3'b000 : freq1[3:0] <= data[3:0];
+            3'b010 : freq2[3:0] <= data[3:0];
+            3'b100 : freq3[3:0] <= data[3:0];
+            3'b110 : ctrl4 <= data[2:0];
+            3'b001 : vol1[3:0] <= data[3:0];
+            3'b011 : vol2[3:0] <= data[3:0];
+            3'b101 : vol3[3:0] <= data[3:0];
+            3'b111 : vol4[3:0] <= data[3:0];
+            default : begin end
+          endcase
+          prev_reg <= data[6:4];
+        end else begin
+          case(prev_reg)
+            3'b000 : freq1[9:4] <= data[5:0];
+            3'b010 : freq2[9:4] <= data[5:0];
+            3'b100 : freq3[9:4] <= data[5:0];
+            3'b001 : vol1[3:0] <= data[3:0];
+            3'b011 : vol2[3:0] <= data[3:0];
+            3'b101 : vol3[3:0] <= data[3:0];
+            3'b111 : vol4[3:0] <= data[3:0];
+            default : begin end
+          endcase
+        end
+      end
+    end
+  end
+  
+  
+endmodule

--- a/opsg_noise.v
+++ b/opsg_noise.v
@@ -1,0 +1,69 @@
+/*******************************************************************//**
+ *  \file opsg_noise.v
+ *  \author René Richard
+ *  \brief This module implements
+ *
+ *  \copyright This file is part of OPSG.
+ *
+ *   OPSG is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   OPSG is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with OPSG.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+module opsg_noise #(
+  parameter TAPPED_BIT0 = 0,
+  parameter TAPPED_BIT1 = 3,
+  parameter SHIFT_WIDTH = 15,
+  parameter TONE_WIDTH = 10
+)(
+  input clk,
+  input fb,
+  input [1:0] nf,
+  input [TONE_WIDTH-1:0] freq,
+  output reg [TONE_WIDTH-1:0] count,
+  output reg [SHIFT_WIDTH-1:0] shiftReg,
+  output reg noiseBit
+);
+  
+  // init counter to 1, nbit to 1;
+  reg [TONE_WIDTH-1:0] counter = 1;
+  reg [SHIFT_WIDTH-1:0] shift = { 1'b1, { SHIFT_WIDTH-1 {1'b0} } };
+  reg nbit = 1'b1;
+  reg feedback;
+  
+  always @(posedge clk) begin
+    if ( counter == 1 ) begin
+      case(nf)
+        2'b00 : counter <= 16;
+        2'b01 : counter <= 32;
+        2'b10 : counter <= 64;
+        // noiseFreq to be connected to tone channel 3
+        default : counter <= freq;
+      endcase
+   	  nbit <= !nbit;
+    end else begin
+      counter <= counter - 1;
+    end
+    count = counter;
+  end
+  
+  always @(posedge nbit) begin
+    if (fb) begin
+      shift <= { (shift[TAPPED_BIT0] ^ shift[TAPPED_BIT1]), shift[SHIFT_WIDTH-1:1] };
+    end else begin
+      shift <= { shift[0], shift[SHIFT_WIDTH-1:1] };
+    end
+    shiftReg = shift;
+    noiseBit = shift[0];
+  end
+  
+endmodule

--- a/opsg_noise.v
+++ b/opsg_noise.v
@@ -20,50 +20,57 @@
  */
 
 module opsg_noise #(
-  parameter TAPPED_BIT0 = 0,
-  parameter TAPPED_BIT1 = 3,
-  parameter SHIFT_WIDTH = 15,
-  parameter TONE_WIDTH = 10
+	parameter TAPPED_BIT0 = 0,
+	parameter TAPPED_BIT1 = 3,
+	parameter SHIFT_WIDTH = 15,
+	parameter TONE_WIDTH = 10
 )(
-  input clk,
-  input fb,
-  input [1:0] nf,
-  input [TONE_WIDTH-1:0] freq,
-  output reg [TONE_WIDTH-1:0] count,
-  output reg [SHIFT_WIDTH-1:0] shiftReg,
-  output reg noiseBit
+	input clk,
+	input reload,
+	input fb,
+	input [1:0] nf,
+	input [TONE_WIDTH-1:0] freq,
+	output reg [TONE_WIDTH-1:0] count,
+	output reg [SHIFT_WIDTH-1:0] shiftReg,
+	output reg noiseBit
 );
   
-  // init counter to 1, nbit to 1;
-  reg [TONE_WIDTH-1:0] counter = 1;
-  reg [SHIFT_WIDTH-1:0] shift = { 1'b1, { SHIFT_WIDTH-1 {1'b0} } };
-  reg nbit = 1'b1;
-  reg feedback;
+	// init counter to 1, nbit to 1;
+	reg [TONE_WIDTH-1:0] counter = 1;
+	reg [SHIFT_WIDTH-1:0] shift = { 1'b1, { SHIFT_WIDTH-1 {1'b0} } };
+	reg nbit = 1'b1;
+	reg feedback;
   
-  always @(posedge clk) begin
-    if ( counter == 1 ) begin
-      case(nf)
-        2'b00 : counter <= 16;
-        2'b01 : counter <= 32;
-        2'b10 : counter <= 64;
-        // noiseFreq to be connected to tone channel 3
-        default : counter <= freq;
-      endcase
-   	  nbit <= !nbit;
-    end else begin
-      counter <= counter - 1;
-    end
-    count = counter;
-  end
+	always @(posedge clk) begin
+		if ( counter == 1 ) begin
+			case(nf)
+				2'b00 : counter <= 16;
+				2'b01 : counter <= 32;
+				2'b10 : counter <= 64;
+				// noiseFreq to be connected to tone channel 3
+				default : counter <= freq;
+			endcase
+			nbit <= !nbit;
+		end else begin
+			counter <= counter - 1;
+		end
+		count = counter;
+	end
   
-  always @(posedge nbit) begin
-    if (fb) begin
-      shift <= { (shift[TAPPED_BIT0] ^ shift[TAPPED_BIT1]), shift[SHIFT_WIDTH-1:1] };
-    end else begin
-      shift <= { shift[0], shift[SHIFT_WIDTH-1:1] };
-    end
-    shiftReg = shift;
-    noiseBit = shift[0];
-  end
+	// LFSR needs to reset on each freq write to the noise channel
+	// reset value is top bit getting set while all others are back to zero. 
+	always @(posedge nbit, negedge reload) begin
+		if (!reload) begin
+			shift <= { 1'b1, { SHIFT_WIDTH-1 {1'b0} } };
+		end else begin
+			if (fb) begin
+				shift <= { (shift[TAPPED_BIT0] ^ shift[TAPPED_BIT1]), shift[SHIFT_WIDTH-1:1] };
+			end else begin
+				shift <= { shift[0], shift[SHIFT_WIDTH-1:1] };
+			end
+			shiftReg = shift;
+			noiseBit = shift[0];
+		end
+	end
   
 endmodule

--- a/opsg_tb.v
+++ b/opsg_tb.v
@@ -1,7 +1,7 @@
 /*******************************************************************//**
  *  \file opsg.v
  *  \author René Richard
- *  \brief This program contains specific functions for the genesis cartridge
+ *  \brief This module contains a testbench for the opsg top-level module
  *
  *  \copyright This file is part of OPSG.
  *
@@ -23,107 +23,116 @@
 
 module test;
   
-  reg clk, n_rst, n_wr;
-  reg [7:0] data;
-  wire ch1, ch2, ch3, ch4;
-  wire [3:0] audio_bits;
-  wire [15:0] audio_left;
-  wire [15:0] audio_right;
+	reg clk, n_rst, n_wr;
+	reg [7:0] data;
+	wire ch1, ch2, ch3, ch4;
+	wire [3:0] audio_bits;
+	wire [15:0] audio_left;
+	wire [15:0] audio_right;
   
-  // using CLK_DIV 1 just to shrink the simulation length
-  // real hardware needs CLK_DIV = 4
-  opsg #(.MAX_VOLUME(2048), .CLK_DIV(1)) opsg_test(
-    .clk(clk),
-    .n_rst(n_rst),
-    .n_wr(n_wr),
-    .data(data),
-    .ch1(ch1),
-    .ch2(ch2),
-    .ch3(ch3),
-    .ch4(ch4),
-    .audio_left(audio_left),
-    .audio_right(audio_right)
-  );
+	// using CLK_DIV 1 just to shrink the simulation length
+	// real hardware needs CLK_DIV = 4
+	opsg #(.MAX_VOLUME(2048), .CLK_DIV(1)) opsg_test(
+		.clk(clk),
+		.n_rst(n_rst),
+		.n_wr(n_wr),
+		.data(data),
+		.ch1(ch1),
+		.ch2(ch2),
+		.ch3(ch3),
+		.ch4(ch4),
+		.audio_left(audio_left),
+		.audio_right(audio_right)
+	);
   
-  // task to write to the psg
-  task write_psg;
-    input [7:0] value;
-    begin
-      data = value;
-      n_wr = 1'b0;
-      #4 n_wr = 1'b1;
-      #2 data = 8'hFF;
-    end
-  endtask
+	// task to write to the psg
+	task write_psg;
+		input [7:0] value;
+		begin
+			data = value;
+			n_wr = 1'b0;
+			#4 n_wr = 1'b1;
+			#2 data = 8'hFF;
+		end
+	endtask
   
-  always #2 clk = !clk;
+	always #2 clk = !clk;
 
-  initial begin
-    $dumpfile("dump.vcd");
-    $dumpvars(1);
-    
-    clk = 0;
-    n_rst = 0;
-    n_wr = 1;
-    data = 8'hFF;
-    
-    #10 n_rst = 1;
+	initial begin
+		$dumpfile("dump.vcd");
+		$dumpvars(1);
+		
+		clk = 0;
+		n_rst = 0;
+		n_wr = 1;
+		data = 8'hFF;
+		
+		#10 n_rst = 1;
 
-    // write to lower 4 bits of 3 tone channels
-    #100 write_psg(8'b10000011);
-    #100 write_psg(8'b10100100);
-    #100 write_psg(8'b11001000);
-    
-    // test ch1, other volumes to 0
-    #100 write_psg(8'b10010000);
-    #100 write_psg(8'b10111111);
-    #100 write_psg(8'b11011111);
-    #100 write_psg(8'b11111111);
-    
-    #1000
-    
-    // set volumes to all levels
-    #100 write_psg(8'b10010000);
-    #100 write_psg(8'b10110001);
-    #100 write_psg(8'b11010010);
-    #100 write_psg(8'b11110011);
-    #100 write_psg(8'b10010100);
-    #100 write_psg(8'b10110101);
-    #100 write_psg(8'b11010110);
-    #100 write_psg(8'b11110111);
-    
-    #100 write_psg(8'b10011000);
-    #100 write_psg(8'b10111001);
-    #100 write_psg(8'b11011010);
-    #100 write_psg(8'b11111011);
-    #100 write_psg(8'b10011100);
-    #100 write_psg(8'b10111101);
-    #100 write_psg(8'b11011110);
-    #100 write_psg(8'b11111111);
-    
-    //all channels to max
-    #100 write_psg(8'b10010000);
-    #100 write_psg(8'b10110000);
-    #100 write_psg(8'b11010000);
-    #100 write_psg(8'b11110000);
-    
-    // write to lower 4 bits followed by upper bits to test prev_reg
-    #1000
-    write_psg(8'b10000000);
-    write_psg(8'b00000011);
-    #100
-    write_psg(8'b10100000);
-    write_psg(8'b00100110);
-    #100
-    write_psg(8'b11000000);
-    write_psg(8'b01001000);
-    
-    // decrease noise frequency
-    #100
-    write_psg(8'b11100001);
-    
-    
-    #20000 $finish;
-  end
+		// write to lower 4 bits of 3 tone channels
+		#100 write_psg(8'b10000011);
+		#100 write_psg(8'b10100100);
+		#100 write_psg(8'b11001000);
+		
+		// test ch1, other volumes to 0
+		#100 write_psg(8'b10010000);
+		#100 write_psg(8'b10111111);
+		#100 write_psg(8'b11011111);
+		#100 write_psg(8'b11111111);
+		
+		#1000
+		
+		// set volumes to all levels
+		#100 write_psg(8'b10010000);
+		#100 write_psg(8'b10110001);
+		#100 write_psg(8'b11010010);
+		#100 write_psg(8'b11110011);
+		#100 write_psg(8'b10010100);
+		#100 write_psg(8'b10110101);
+		#100 write_psg(8'b11010110);
+		#100 write_psg(8'b11110111);
+		
+		#100 write_psg(8'b10011000);
+		#100 write_psg(8'b10111001);
+		#100 write_psg(8'b11011010);
+		#100 write_psg(8'b11111011);
+		#100 write_psg(8'b10011100);
+		#100 write_psg(8'b10111101);
+		#100 write_psg(8'b11011110);
+		#100 write_psg(8'b11111111);
+		
+		//all channels to max
+		#100 write_psg(8'b10010000);
+		#100 write_psg(8'b10110000);
+		#100 write_psg(8'b11010000);
+		#100 write_psg(8'b11110000);
+		
+		// write to lower 4 bits followed by upper bits to test prev_reg
+		#1000
+		write_psg(8'b10000000);
+		write_psg(8'b00000011);
+		#100
+		write_psg(8'b10100000);
+		write_psg(8'b00100110);
+		#100
+		write_psg(8'b11000000);
+		write_psg(8'b01001000);
+		
+		// write to noise frequency, test reset of shift register
+		#20000
+		write_psg(8'b11100101);
+		#80000
+		write_psg(8'b11100100);
+		#80000
+		write_psg(8'b11100000);
+		#80000
+		
+		// set tone channel 2 to low period to test noise channel
+		write_psg(8'b11000100);
+		write_psg(8'b01000000);
+		write_psg(8'b11100011);
+		
+		#80000 $finish;
+	end
   
 endmodule

--- a/opsg_tb.v
+++ b/opsg_tb.v
@@ -1,5 +1,26 @@
-// Code your testbench here
-// or browse Examples
+/*******************************************************************//**
+ *  \file opsg.v
+ *  \author René Richard
+ *  \brief This program contains specific functions for the genesis cartridge
+ *
+ *  \copyright This file is part of OPSG.
+ *
+ *   OPSG is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   OPSG is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with OPSG.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//`include "opsg.v"
+
 module test;
   
   reg clk, n_rst, n_wr;

--- a/opsg_tb.v
+++ b/opsg_tb.v
@@ -1,0 +1,108 @@
+// Code your testbench here
+// or browse Examples
+module test;
+  
+  reg clk, n_rst, n_wr;
+  reg [7:0] data;
+  wire ch1, ch2, ch3, ch4;
+  wire [3:0] audio_bits;
+  wire [15:0] audio_left;
+  wire [15:0] audio_right;
+  
+  // using CLK_DIV 1 just to shrink the simulation length
+  // real hardware needs CLK_DIV = 4
+  opsg #(.MAX_VOLUME(2048), .CLK_DIV(1)) opsg_test(
+    .clk(clk),
+    .n_rst(n_rst),
+    .n_wr(n_wr),
+    .data(data),
+    .ch1(ch1),
+    .ch2(ch2),
+    .ch3(ch3),
+    .ch4(ch4),
+    .audio_left(audio_left),
+    .audio_right(audio_right)
+  );
+  
+  // task to write to the psg
+  task write_psg;
+    input [7:0] value;
+    begin
+      data = value;
+      n_wr = 1'b0;
+      #4 n_wr = 1'b1;
+      #2 data = 8'hFF;
+    end
+  endtask
+  
+  always #2 clk = !clk;
+
+  initial begin
+    $dumpfile("dump.vcd");
+    $dumpvars(1);
+    
+    clk = 0;
+    n_rst = 0;
+    n_wr = 1;
+    data = 8'hFF;
+    
+    #10 n_rst = 1;
+
+    // write to lower 4 bits of 3 tone channels
+    #100 write_psg(8'b10000011);
+    #100 write_psg(8'b10100100);
+    #100 write_psg(8'b11001000);
+    
+    // test ch1, other volumes to 0
+    #100 write_psg(8'b10010000);
+    #100 write_psg(8'b10111111);
+    #100 write_psg(8'b11011111);
+    #100 write_psg(8'b11111111);
+    
+    #1000
+    
+    // set volumes to all levels
+    #100 write_psg(8'b10010000);
+    #100 write_psg(8'b10110001);
+    #100 write_psg(8'b11010010);
+    #100 write_psg(8'b11110011);
+    #100 write_psg(8'b10010100);
+    #100 write_psg(8'b10110101);
+    #100 write_psg(8'b11010110);
+    #100 write_psg(8'b11110111);
+    
+    #100 write_psg(8'b10011000);
+    #100 write_psg(8'b10111001);
+    #100 write_psg(8'b11011010);
+    #100 write_psg(8'b11111011);
+    #100 write_psg(8'b10011100);
+    #100 write_psg(8'b10111101);
+    #100 write_psg(8'b11011110);
+    #100 write_psg(8'b11111111);
+    
+    //all channels to max
+    #100 write_psg(8'b10010000);
+    #100 write_psg(8'b10110000);
+    #100 write_psg(8'b11010000);
+    #100 write_psg(8'b11110000);
+    
+    // write to lower 4 bits followed by upper bits to test prev_reg
+    #1000
+    write_psg(8'b10000000);
+    write_psg(8'b00000011);
+    #100
+    write_psg(8'b10100000);
+    write_psg(8'b00100110);
+    #100
+    write_psg(8'b11000000);
+    write_psg(8'b01001000);
+    
+    // decrease noise frequency
+    #100
+    write_psg(8'b11100001);
+    
+    
+    #20000 $finish;
+  end
+  
+endmodule

--- a/opsg_tb.v
+++ b/opsg_tb.v
@@ -76,11 +76,17 @@ module test;
 		
 		// test ch1, other volumes to 0
 		#100 write_psg(8'b10010000);
-		#100 write_psg(8'b10111111);
-		#100 write_psg(8'b11011111);
-		#100 write_psg(8'b11111111);
+		write_psg(8'b10111111);
+		write_psg(8'b11011111);
+		write_psg(8'b11111111);
 		
+		// volume value 10 should be 0.1 of original volume
 		#1000
+		write_psg(8'b10011010);
+		write_psg(8'b10111010);
+		write_psg(8'b11011010);
+		write_psg(8'b11111010);
+		#10000
 		
 		// set volumes to all levels
 		#100 write_psg(8'b10010000);

--- a/opsg_tone.v
+++ b/opsg_tone.v
@@ -20,35 +20,30 @@
  */
  
 module opsg_tone #(
-  parameter TONE_WIDTH = 10
+	parameter TONE_WIDTH = 10
 )(
-  input clk,
-  input [TONE_WIDTH-1:0] freq,
-  output reg [TONE_WIDTH-1:0] count,
-  output reg toneBit
+	input clk,
+	input [TONE_WIDTH-1:0] freq,
+	output reg [TONE_WIDTH-1:0] count,
+	output reg toneBit
 );
 
-  // init counter to 1, tbit to 1;
-  reg [TONE_WIDTH-1:0] counter = 1;
-  reg tbit = 1'b1;
-  
-  always @(posedge clk) begin
- 
-    counter <= counter - 1;
-    
-    if ( counter == 0 ) begin
-      // output of tone channel forced to 1 if freq == 0 (used for sample playback)
-      if ( freq == 0 ) begin
-      	tbit <= 1'b1;
-      end else begin
- 		tbit <= !tbit;      
-      end
-      counter <= freq;
-    end
-    
-    count = counter;
-    toneBit = tbit;
-    
-  end
-  
+	// init counter to 1, tbit to 1;
+	reg [TONE_WIDTH-1:0] counter = 1;
+	reg tbit = 1'b1;
+
+	always @(posedge clk) begin
+		counter <= counter - 1;
+		if ( counter == 0 ) begin
+			// output of tone channel forced to 1 if freq == 0 (used for sample playback)
+			if ( freq == 0 ) begin
+				tbit <= 1'b1;
+			end else begin
+				tbit <= !tbit;      
+			end
+			counter <= freq;
+		end
+		count = counter;
+		toneBit = tbit;
+	end
 endmodule

--- a/opsg_tone.v
+++ b/opsg_tone.v
@@ -1,0 +1,54 @@
+/*******************************************************************//**
+ *  \file opsg_tone.v
+ *  \author René Richard
+ *  \brief This module implements
+ *
+ *  \copyright This file is part of OPSG.
+ *
+ *   OPSG is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   OPSG is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with OPSG.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+module opsg_tone #(
+  parameter TONE_WIDTH = 10
+)(
+  input clk,
+  input [TONE_WIDTH-1:0] freq,
+  output reg [TONE_WIDTH-1:0] count,
+  output reg toneBit
+);
+
+  // init counter to 1, tbit to 1;
+  reg [TONE_WIDTH-1:0] counter = 1;
+  reg tbit = 1'b1;
+  
+  always @(posedge clk) begin
+ 
+    counter <= counter - 1;
+    
+    if ( counter == 0 ) begin
+      // output of tone channel forced to 1 if freq == 0 (used for sample playback)
+      if ( freq == 0 ) begin
+      	tbit <= 1'b1;
+      end else begin
+ 		tbit <= !tbit;      
+      end
+      counter <= freq;
+    end
+    
+    count = counter;
+    toneBit = tbit;
+    
+  end
+  
+endmodule


### PR DESCRIPTION
This OPSG verilog core verifies all of the PSG features I can currently find under testbench. Here are a few things over and above the current MiSTer PSG:

- proper 2dB volume scaling
- proper noise shift register reset on frequency writes
- 16 bit audio out (stereo Gamegear support coming soon!)
- parameterized OPSG top-level module to allow for most variants (noise tap bits, shift register length)